### PR TITLE
Add before and after hooks only for Features and Scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,57 @@ Feature('Some feature', () => {
 
 <img src="doc/only-v2.png" width="400" />
 
+### `beforeEachScenario` and `afterEachScenario`
+
+Executes the provided function only once for each of the scenarios under the current scope.
+
+```javascript
+Feature('Some feature', () => {
+
+  beforeEachScenario( () => {
+    someSetup();
+  });
+
+  afterEachScenario( () => {
+    doCleanup();
+  });
+
+  Scenario('First scenario', () => {
+    // ...
+  });
+
+  Scenario('Second scenario', () => {
+    // ...
+  });
+
+  // ...
+});
+```
+
+### `beforeEachFeature` and `afterEachFeature`
+
+Executes the provided function only once for each of the features under the current scope.
+
+```javascript
+beforeEachFeature( () => {
+  someSetup();
+});
+
+afterEachFeature( () => {
+  doCleanup();
+});
+
+Feature('Some feature', () => {
+  // ...
+});
+
+Feature('Another feature', () => {
+  // ...
+});
+
+// ...
+```
+
 ## Acknowledgements
 
 Mocha Cakes 2 is heavily influenced by **quangv**'s [mocha-cakes](https://github.com/quangv/mocha-cakes/).

--- a/test/feature/sample-tests/hooks-per-type-test.js
+++ b/test/feature/sample-tests/hooks-per-type-test.js
@@ -1,0 +1,81 @@
+'use-strict';
+
+beforeEachScenario(function() {
+  console.log('Global beforeEachScenario');
+});
+
+afterEachScenario(function() {
+  console.log('Global afterEachScenario');
+});
+
+beforeEachFeature(function() {
+  console.log('Global beforeEachFeature');
+});
+
+afterEachFeature(function() {
+  console.log('Global afterEachFeature');
+});
+
+Feature('Mocha Cakes', function () {
+
+  beforeEachFeature(function() {
+    console.log('Feature internal beforeEachFeature');
+  });
+
+  afterEachFeature(function() {
+    console.log('Feature internal afterEachFeature');
+  });
+
+  beforeEachScenario(function() {
+    console.log('Feature internal beforeEachScenario');
+  });
+
+  afterEachScenario(function() {
+    console.log('Feature internal afterEachScenario');
+  });
+
+  Scenario('Testing mocha cakes', function () {
+
+    beforeEachScenario(function() {
+      console.log('Scenario internal beforeEachScenario');
+    });
+
+    afterEachScenario(function() {
+      console.log('Scenario internal afterEachScenario');
+    });
+
+    When('something is true', function () {
+      true.should.equal(true);
+    });
+
+    Then('everything should be ok', function () {
+      "everything".should.be.ok;
+    });
+  });
+
+  Scenario('Testing mocha cakes again', function () {
+
+    When('something is true', function () {
+      true.should.equal(true);
+    });
+
+    Then('everything should be ok', function () {
+      "everything".should.be.ok;
+    });
+  });
+});
+
+Feature('Mocha Cakes 2', function () {
+
+  Scenario('Testing mocha cakes in negative', function () {
+
+    When('something is false', function () {
+      false.should.equal(false);
+    });
+
+    Then('everything should be ok', function () {
+      "everything".should.be.ok;
+    });
+  });
+});
+

--- a/test/feature/tests.js
+++ b/test/feature/tests.js
@@ -193,6 +193,58 @@ describe('Mocha Cakes', function () {
     });
   });
 
+  describe("A test file with Hooks per type", function () {
+
+    var output;
+
+    before(function () {
+      return execTestFile('feature/sample-tests/hooks-per-type-test.js')
+        .then(function (result) {
+          output = result;
+        });
+    });
+
+    it('should execute the beforeEachFeature clause before each feature', function () {
+      output.match(/Global beforeEachFeature/g).length.should.equal(2);
+    });
+
+    it('should execute the afterEachFeature clause after each feature', function () {
+      output.match(/Global afterEachFeature/g).length.should.equal(2);
+    });
+
+    it('should not execute the beforeEachFeature clause in absence of nested Features', function () {
+      output.should.not.match(/Feature internal beforeEachFeature/g);
+    });
+
+    it('should not execute the afterEachFeature clause in absence of nested Features', function () {
+      output.should.not.match(/Feature internal beforeEachFeature/g);
+    });
+
+    it('should execute the beforeEachScenario clause before each scenario', function () {
+      output.match(/Global beforeEachScenario/g).length.should.equal(3);
+    });
+
+    it('should execute the afterEachScenario clause after each scenario', function () {
+      output.match(/Global afterEachScenario/g).length.should.equal(3);
+    });
+
+    it('should execute the beforeEachScenario clause on nested scenarios', function () {
+      output.match(/Feature internal beforeEachScenario/g).length.should.equal(2);
+    });
+
+    it('should execute the afterEachScenario clause on nested scenario', function () {
+      output.match(/Feature internal afterEachScenario/g).length.should.equal(2);
+    });
+
+    it('should not execute the beforeEachScenario clause in absence of nested Scenarios', function () {
+      output.should.not.match(/Feature internal beforeEachFeature/g);
+    });
+
+    it('should not execute the afterEachFeature clause in absence of nested Features', function () {
+      output.should.not.match(/Feature internal beforeEachFeature/g);
+    });
+  });
+
   describe('Lower-case aliases', function () {
     var output;
 


### PR DESCRIPTION
This commit adds four functions to context: beforeEachFeature,
beforeEachScenario, afterEachFeature and afterEachScenario. They set
hooks that would only be executed on nested Features and Scenarios
respectively.

This is convenient to setup all the Features and Scenarios without
requiring a before or after for each of them.

-----------------------------------------------------------

First of all, thanks in advance for your time reviewing this.

I'm working in a project which adopted `mocha-cakes-2` recently and last week we've missed a feature. We were setting a bunch of `Scenarios` inside a feature, and we wanted to provide a clean state (in this case, a clean database) for each `Scenario`, but share that state between all the tests inside the `Scenario`.

We ended up adding the same `before` hook on each `Scenario`. I've found that solution not quite satisfactory so I tried to implement a `beforeEachScenario` hook that would solve our problem in a rather elegant way.

For the same price, I've also implemented `beforeEachFeature`, `afterEachFeature` and `afterEachScenario`. I'm not sure about the order in which the hooks should executed, so maybe it's worth having an extra look at that.

I'm not that familiar with the mocha ecosystem, so maybe there's a better way to implement this. In any case, this would be a nice feature for us and I hope you find that it has a place in this module.