### PR TITLE
Fix using the Mocha API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,42 @@ npm install --save-dev mocha-cakes-2
 
 ## Usage
 
-You need to specify `mocha-cakes-2` as a mocha integration by adding the option `--ui mocha-cakes-2` to your `mocha` command:
+### Enable the mocha-cakes-2 integration
+
+To enable the Mocha integration you need to specify `mocha-cakes-2` in the `ui` option.
+
+#### CLI
+
+Either use the command line argument:
 
 ``` javascript
 mocha --ui mocha-cakes-2 path/to/my/tests
 ```
 
-You can also specify it in your [`mocha.opts`](https://mochajs.org/#mochaopts) file:
+Or set it in your [`mocha.opts`](https://mochajs.org/#mochaopts) file:
 
 ``` javascript
 --ui mocha-cakes-2
 ```
+
+#### API
+
+Either pass it in the options as you construct Mocha:
+
+``` javascript
+var mocha = new Mocha({
+  ui: 'mocha-cakes-2'
+});
+```
+
+Or set it after you've constructed Mocha:
+
+``` javascript
+var mocha = new Mocha();
+mocha.ui('mocha-cakes-2')
+```
+
+### Test structure
 
 ```javascript
 require('chai').should();
@@ -225,6 +250,16 @@ Feature('Another feature', () => {
 
 // ...
 ```
+
+## Development
+
+### Testing the CLI and API interfaces
+
+If you use Mocha directly to run the tests you can set the `MOCHA_INTERFACE` environment variable to either `cli` or `api` to choose which Mocha interface to run the tests with: `MOCHA_INTERFACE=api mocha test/feature/tests.js`.
+
+`MOCHA_INTERFACE` will default to `cli` if no value is set.
+
+When you run `npm run test:cli` or `npm run test:api` (or `npm test` to run them both), `MOCHA_INTERFACE` is set automatically to the appropriate value.
 
 ## Acknowledgements
 

--- a/mocha-cakes.js
+++ b/mocha-cakes.js
@@ -47,6 +47,7 @@ function mochaCakes(suite) {
     context.And = testTypeCreator('And');
     context.But = testTypeCreator('But');
     context.it = testTypeCreator('');
+    context.xit = context.it.skip;
 
     // lower-case aliases
     context.scenario = context.Scenario;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "mocha-cakes.js",
   "typings": "./mocha-cakes.d.ts",
   "scripts": {
-    "test": "mocha ./test/**/*tests.js",
+    "test": "npm run test:cli && npm run test:api",
+    "test:cli": "MOCHA_INTERFACE=cli mocha ./test/**/*tests.js",
+    "test:api": "MOCHA_INTERFACE=api node ./test/run-api.js",
     "test:watch": "mocha ./test/**/*tests.js --watch -R dot"
   },
   "repository": {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,20 +1,91 @@
 'use strict';
 
+var Mocha = require('mocha');
 var Promise = require('bluebird');
 var execFile = Promise.promisify(require('child_process').execFile);
 var path = require('path');
 
 var testEnv = Object.assign({}, process.env, { NODE_PATH: __dirname });
 
+var defaultOpts = {
+  reporter: 'spec'
+};
+
+var formatRegexp = /%[ds]/
+
+var interfaces = {
+  cli: function(file, opts) {
+    opts = Object.assign({}, defaultOpts, opts);
+    var args = [
+      '--require', path.join(__dirname, '../mocha-cakes.js'),
+      '--ui', 'mocha-cakes',
+      '--reporter', opts.reporter,
+      path.join(__dirname, file)
+    ];
+    return execFile('mocha', args, { env: testEnv });
+  },
+
+  api: function(file, opts) {
+    return new Promise(function(resolve) {
+      opts = Object.assign({}, defaultOpts, opts);
+
+      // The set up from requiring mocha-cakes and running chai.should() in `run-api.js`
+      // is inherited here so we don't need to set them up for each file we run.
+
+      var mocha = new Mocha({
+        ui: 'mocha-cakes-2',
+        reporter: opts.reporter,
+        // Since we're intercepting the console messages before they're formatted
+        // we would get the color strings in the output, but that doesn't happen
+        // in the CLI output since the colors are formatted and won't appear in the
+        // strings, so we disable colors here so we don't have to strip them from
+        // the output, and we can use the same test assertions with both interfaces.
+        useColors: false
+      });
+
+      mocha.addFile(path.join(__dirname, file));
+
+      // Override console.log() so we can get the output from the reporter.
+      var logs = [];
+      var originalLog = console.log
+      console.log = function() {
+        var args = Array.prototype.slice.call(arguments);
+        if (args.length < 2) {
+          logs.push(args[0] || '');
+        } else {
+          var str = args.reduce(function(str, arg) {
+            if (formatRegexp.test(str)) {
+              return str.replace(formatRegexp, arg);
+            }
+            return str + ' ' + arg;
+          });
+          logs.push(str);
+        }
+      }
+
+      // Mocha.run() will store the 'useColors' option internally, outside of the
+      // options we've set for this instance, so if the Mocha instance that's
+      // running this has a different 'useColors' value it won't be restored.
+      var previousUseColors = Mocha.reporters.Base.useColors;
+
+      mocha.run(function() {
+        console.log = originalLog;
+        Mocha.reporters.Base.useColors = previousUseColors;
+        resolve(logs.join('\n'));
+      });
+    });
+  }
+}
+
 function execTestFile(file, opts) {
-  opts = Object.assign({ reporter: 'spec' }, opts);
-  var args = [
-    '--require', path.join(__dirname, '../mocha-cakes.js'),
-    '--ui', 'mocha-cakes',
-    '--reporter', opts.reporter,
-    path.join(__dirname, file)
-  ];
-  return execFile('mocha', args, { env: testEnv });
+  var interfaceName = process.env.MOCHA_INTERFACE || 'cli';
+  var func = interfaces[interfaceName];
+  if (!func) {
+    var actual = typeof interfaceName !== 'undefined' ? JSON.stringify(interfaceName) : 'undefined';
+    var valid = Object.keys(interfaces).join(', ');
+    throw new Error('The MOCHA_INTERFACE environment variable is set to ' + actual + ', valid values are: ' + valid);
+  }
+  return func(file, opts);
 }
 
 module.exports = {

--- a/test/run-api.js
+++ b/test/run-api.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var Mocha = require('mocha');
+var chai = require('chai');
+
+require('../mocha-cakes');
+
+chai.should();
+
+var mocha = new Mocha({
+  ui: 'mocha-cakes-2',
+  reporter: 'spec'
+});
+
+mocha.addFile('test/feature/tests.js');
+
+mocha.run(function(failureCount) {
+  process.on("exit", function() {
+    process.exit(failureCount);
+  });
+});


### PR DESCRIPTION
When Mocha is run using the CLI [the default `ui` is first set up](https://github.com/mochajs/mocha/blob/v5.0.5/bin/_mocha#L21), which sets `context.xit`, and [then that setup is overriden](https://github.com/mochajs/mocha/blob/v5.0.5/bin/_mocha#L472) by the `ui` you've specified in the options, so the non-default `ui` can "inherit" parts of the default `ui` by not overriding them.

But when you use the API and construct Mocha with the `ui` option (`const mocha = new Mocha({ui: 'mocha-cakes-2'})`) the default `ui` isn't set up first so Mocha will throw an error [when it runs `exports.xit = context.xit || context.test.skip`](https://github.com/mochajs/mocha/blob/v5.0.5/lib/mocha.js#L207) because mocha-cakes-2 has not set `context.xit` or `context.test`.